### PR TITLE
clear entity manager before running tests

### DIFF
--- a/test/integration/JoinHandler.e2e-spec.ts
+++ b/test/integration/JoinHandler.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { EntityManager, RequestContext } from '@mikro-orm/core';
+import { EntityManager, MikroORM, RequestContext } from '@mikro-orm/core';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { NestApplication } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
@@ -18,12 +18,15 @@ describe('JoinHandler', () => {
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [JoinModule, DatabaseModule.forTests(true)],
+      imports: [JoinModule, DatabaseModule.forTests(false)],
     }).compile();
 
     app = moduleRef.createNestApplication();
     em = moduleRef.get(EntityManager).fork();
     handler = moduleRef.get(JoinHandler);
+    const orm = moduleRef.get(MikroORM);
+
+    await orm.schema.refreshDatabase();
     await app.init();
   });
 
@@ -34,6 +37,7 @@ describe('JoinHandler', () => {
     beforeEach(async () => {
       contestant = Contestant.create(false, USER_ID);
       await em.persistAndFlush(contestant);
+      em.clear();
     });
 
     test('When the contestant joins, Then the contestant is added to the group Finder', async () => {


### PR DESCRIPTION
Gives the following error:
```

 JoinHandler
    Given a contestant who has not joined
      ✕ When the contestant joins, Then the contestant is added to the group Finder (198 ms)
    Given a contestant who has already joined
      ✕ When the contestant tries to join, Then the contestant is told they have already joined (79 ms)

  ● JoinHandler › Given a contestant who has not joined › When the contestant joins, Then the contestant is added to the group Finder

    ValidationError: Using global EntityManager instance methods for context specific actions is disallowed. If you need to work with the global instance's identity map, use `allowGlobalContext` configuration option or `fork()` instead.

      18 |    */
      19 |   public async execute(command: JoinCommand): Promise<void> {
    > 20 |     const contestant = await this._em.findOneOrFail(Contestant, {
         |                                       ^
      21 |       userId: command.userId,
      22 |     });
      23 |

      at Function.cannotUseGlobalContext (node_modules/@mikro-orm/core/errors.js:96:16)
      at SqlEntityManager.getContext (node_modules/@mikro-orm/core/EntityManager.js:1417:44)
      at SqlEntityManager.findOne (node_modules/@mikro-orm/core/EntityManager.js:495:25)
      at SqlEntityManager.findOneOrFail (node_modules/@mikro-orm/core/EntityManager.js:567:33)
      at JoinHandler.execute (src/modules/contestant/features/join/JoinHandler.ts:20:39)
      at Object.<anonymous> (test/integration/JoinHandler.e2e-spec.ts:45:21)

  ● JoinHandler › Given a contestant who has already joined › When the contestant tries to join, Then the contestant is told they have already joined

    ValidationError: Using global EntityManager instance methods for context specific actions is disallowed. If you need to work with the global instance's identity map, use `allowGlobalContext` configuration option or `fork()` instead.

      18 |    */
      19 |   public async execute(command: JoinCommand): Promise<void> {
    > 20 |     const contestant = await this._em.findOneOrFail(Contestant, {
         |                                       ^
      21 |       userId: command.userId,
      22 |     });
      23 |

      at Function.cannotUseGlobalContext (node_modules/@mikro-orm/core/errors.js:96:16)
      at SqlEntityManager.getContext (node_modules/@mikro-orm/core/EntityManager.js:1417:44)
      at SqlEntityManager.findOne (node_modules/@mikro-orm/core/EntityManager.js:495:25)
      at SqlEntityManager.findOneOrFail (node_modules/@mikro-orm/core/EntityManager.js:567:33)
      at JoinHandler.execute (src/modules/contestant/features/join/JoinHandler.ts:20:39)
      at Object.<anonymous> (test/integration/JoinHandler.e2e-spec.ts:65:21)
```